### PR TITLE
Improve color picker responsiveness

### DIFF
--- a/src/components/ThemeControls.tsx
+++ b/src/components/ThemeControls.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef } from 'react';
 import { ChromePicker } from 'react-color';
 import type { ColorResult } from 'react-color';
 import styled from 'styled-components';
+import useDebouncedCallback from '../hooks/useDebouncedCallback';
 
 type SectionVisibilityState = {
   picture: boolean;
@@ -216,8 +217,10 @@ const ThemeControls: React.FC<ThemeControlsProps> = ({
     setSectionVisibility(prev => ({ ...prev, [key]: !prev[key] }));
   };
 
+  const debouncedUpdateTheme = useDebouncedCallback(updateTheme, 100);
+
   const handleColorChange = (key: keyof typeof theme, color: ColorResult) => {
-    updateTheme({ [key]: color.hex });
+    debouncedUpdateTheme({ [key]: color.hex });
   };
 
   return (

--- a/src/hooks/useDebouncedCallback.ts
+++ b/src/hooks/useDebouncedCallback.ts
@@ -1,0 +1,20 @@
+import { useRef, useCallback } from 'react';
+
+export default function useDebouncedCallback<P extends unknown[]>(
+  callback: (...args: P) => void,
+  delay: number
+): (...args: P) => void {
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  return useCallback(
+    (...args: P) => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+      timeoutRef.current = setTimeout(() => {
+        callback(...args);
+      }, delay);
+    },
+    [callback, delay]
+  );
+}


### PR DESCRIPTION
## Summary
- debounce theme updates to avoid laggy color picker
- introduce `useDebouncedCallback` hook to debounce callbacks

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*
- `npm run build` *(fails: build errors in other files)*

------
https://chatgpt.com/codex/tasks/task_e_68407814cbf48333b97cbac28665956b