### PR TITLE
Fix layout shift from autosave status

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -27,6 +27,8 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
+  /* Keep vertical scrollbar space reserved to avoid layout shifts */
+  overflow-y: scroll;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- stop page from jerking sideways when save status message appears by always reserving vertical scrollbar space

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6842e4c3294883339c530da436f94d67